### PR TITLE
add data volume to docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Docker is a tool designed to make it easier to create, deploy, and run applicati
   - **Build and Run with Docker** The first step is to build the Docker image for the LLM App. You do this with the docker build command.
     Build the image:
     ```bash
-    docker build -t llm-app .
+    docker compose -f deployment/docker-compose.yml build
     ```
     After your image is built, you can run it as a container. You use the docker compose run command to do this
     ```bash

--- a/README.md
+++ b/README.md
@@ -86,10 +86,12 @@ Docker is a tool designed to make it easier to create, deploy, and run applicati
     ```bash
     docker build -t llm-app .
     ```
-    After your image is built, you can run it as a container. You use the docker run command to do this
+    After your image is built, you can run it as a container. You use the docker compose run command to do this
     ```bash
-    docker run -it -p 8080:8080 llm-app
+    docker compose -f deployment/docker-compose.yml run -p 8080:8080 llm-app
     ```
+    If you have set a different port in `PATHWAY_REST_CONNECTOR_PORT`, replace the second `8080` with this port in the command above.
+    
     When the process is complete, the App will be up and running inside a Docker container and accessible at `0.0.0.0:8080`. From there, you can proceed to the "Usage" section of the documentation for information on how to interact with the application.
 
 #### Natively:

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,12 +1,13 @@
 version: '3.8'
 services:
   llm-app:
-    build: 
+    build:
       context: ../
       dockerfile: Dockerfile
     volumes:
       - ../llm_app:/app/llm_app
+      - ../data:/app/data
     ports:
       - "8080:8080"
-    env_file: 
+    env_file:
       - ../llm_app/.env


### PR DESCRIPTION
I think it is better to change to docker compose.
`docker run -it -p 8080:8080 -v ./data/:/app/data/ llm-app` doesn't work on the docker version that gets installed by default on ubuntu. To solve it one can use `docker run -it -p 8080:8080 -v $PWD/data/:/app/data/ llm-app` but that will break on windows.
docker compose provides consistent way of attaching a volume on different operating systems.