### PR TITLE
docs: Add get started guide requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ Pathway's **LLM (Large Language Model) App** is a Python library that helps you 
 
 LLM App **does not require** a separate vector database and **avoids the need** for complex and fragmented typical LLM stacks (such as ~Pinecone/Weaviate + Langchain + Redis + FastAPI +...~). Your data remains secure and undisturbed in its original storage location. LLM App's design ensures high performance and offers the flexibility for easy customization and expansion. It is particularly recommended for privacy-preserving LLM applications.
 
-**Quick links** - 💡[Use cases](#use-cases) 📚 [How it works](#how-it-works) 🌟 [Key Features](#key-features) 🏁 [Getting Started](#getting-started) 🛠️ [Troubleshooting](#troubleshooting)
+**Quick links** - 💡[Use cases](#use-cases) 📚 [How it works](#how-it-works) 🌟 [Key Features](#key-features) 🏁 [Get Started](#get-started) 🛠️ [Troubleshooting](#troubleshooting)
 👥 [Contributing](#troubleshooting)
 
 ## Use cases
 
 LLM App examples can be used as templates for developing multiple applications running on top of Pathway. Here are examples of possible uses:
+
 * **Build your own Discord AI chatbot** that answers questions (this is what you see covered in the video!). Or any similar AI chatbot.
 * **Ask privacy-preserving queries** to an LLM using a private knowledge base that is frequently updated.
 * **Extend Kafka-based streaming architectures with LLMs**.
@@ -50,29 +51,37 @@ Read more about the implementation details and how to extend this application in
 
 ### Key Features
 
-- **HTTP REST queries** - The system is capable of responding in real-time to HTTP REST queries.
-- **Real-time document indexing pipeline** - This pipeline reads data directly from S3-compatible storage, without the need to query an extra vector document database.
-- **Code reusability for offline evaluation** - The same code can be used for static evaluation of the system.
-- **Model testing** - Present and past queries can be run against fresh models to evaluate their quality.
+* **HTTP REST queries** - The system is capable of responding in real-time to HTTP REST queries.
+* **Real-time document indexing pipeline** - This pipeline reads data directly from S3-compatible storage, without the need to query an extra vector document database.
+* **Code reusability for offline evaluation** - The same code can be used for static evaluation of the system.
+* **Model testing** - Present and past queries can be run against fresh models to evaluate their quality.
 
 ### Advanced Features
 
-- **Local Machine Learning models** - LLM App can be configured to run with local Machine Learning models, without making API calls outside of the User's Organization.
+* **Local Machine Learning models** - LLM App can be configured to run with local Machine Learning models, without making API calls outside of the User's Organization.
 
-- **Live data sources** - The library can be used to handle live data sources (news feeds, APIs, data streams in Kafka), as well as to include user permissions, a data security layer, and an LLMops monitoring layer.
+* **Live data sources** - The library can be used to handle live data sources (news feeds, APIs, data streams in Kafka), as well as to include user permissions, a data security layer, and an LLMops monitoring layer.
 
-- **User session handling** - The library's query-building process can be used to handle user sessions.
+* **User session handling** - The library's query-building process can be used to handle user sessions.
 
-- To learn more about advanced features see: [Features for Organizations](FEATURES-for-organizations.md).
+* To learn more about advanced features see: [Features for Organizations](FEATURES-for-organizations.md).
 
-### Coming Soon:
+### Coming Soon
 
-- Splitting the application into indexing and request-serving processes easily.
-- Expanding context doc selection with a graph walk / support for a HNSW variant.
-- Model drift and monitoring setup.
-- A guide to model A/B testing.
+* Splitting the application into indexing and request-serving processes easily.
+* Expanding context doc selection with a graph walk / support for a HNSW variant.
+* Model drift and monitoring setup.
+* A guide to model A/B testing.
 
-## Getting Started
+## Get Started
+
+### Prerequisites
+
+1. Make sure that [Python](https://www.python.org/downloads/) 3.10 or above installed on your machine.
+2. Download and Install [Pip](https://pip.pypa.io/en/stable/installation/) to manage project packages.
+3. [Optional if you use OpenAI models]. Create an [OpenAI](https://openai.com/) account and generate a new API Key: To access the OpenAI API, you will need to create an API Key. You can do this by logging into the [OpenAI website](https://openai.com/product) and navigating to the API Key management page.
+4. [Important if you use Windows OS]. Example only supports Unix-like systems (such as Linux, macOS, BSD). If you are a Windows user, we highly recommend leveraging [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) or Dockerize the app to run as a container.
+5. [Optional if you use Docker to run samples]. Download and install [docker](https://www.docker.com/).
 
 To get started explore one of the examples:
 
@@ -81,7 +90,7 @@ To get started explore one of the examples:
 | [`contextless`](examples/pipelines/contextless/app.py)     | This simple example calls OpenAI ChatGPT API but does not use an index when processing queries. It relies solely on the given user query. We recommend it to start your Pathway LLM journey.                                                                                                                                            |
 | [`contextful`](examples/pipelines/contextful/app.py)       | This default example of the app will index the documents located in the `data/pathway-docs` directory. These indexed documents are then taken into account when processing queries. The pathway pipeline being run in this mode is located at [`examples/pipelines/contextful/app.py`](examples/pipelines/contextful/app.py). |
 | [`contextful_s3`](examples/pipelines/contextful_s3/app.py) | This example operates similarly to the contextful mode. The main difference is that the documents are stored and indexed from an S3 bucket, allowing the handling of a larger volume of documents. This can be more suitable for production environments.                                                                                   |
-| [`local`](examples/pipelines/local/app.py)                 | This example runs the application using Huggingface Transformers, which eliminates the need for the data to leave the machine. It provides a convenient way to use state-of-the-art NLP models locally.   
+| [`local`](examples/pipelines/local/app.py)                 | This example runs the application using Huggingface Transformers, which eliminates the need for the data to leave the machine. It provides a convenient way to use state-of-the-art NLP models locally.
 
 And follow the easy steps to install and run one of those examples.
 
@@ -139,15 +148,13 @@ When the process is complete, the App will be up and running inside a Docker con
 
 #### Native Approach
 
-**Important:** The instructions in this section are intended for users operating Unix-like systems (such as Linux, macOS, BSD). If you are a Windows user, we highly recommend leveraging Windows Subsystem for Linux (WSL) or Docker, as outlined in the previous sections, to ensure optimal compatibility and performance.
-
-- **Install poetry:**
+* **Install poetry:**
 
     ```bash
     pip install poetry
     ```
 
-- **Install llm_app and dependencies:** 
+* **Install llm_app and dependencies:**
 
     ```bash
     poetry install --with examples --extras local
@@ -155,12 +162,11 @@ When the process is complete, the App will be up and running inside a Docker con
 
     You can ommit `--extras local` part if you're not going to run local example.
 
-- **Run the examples:** You can start the example with the command:
+* **Run the examples:** You can start the example with the command:
 
     ```bash
     poetry run ./run_examples.py contextful
     ```
-
 
 ### Step 4: Start to use it
 
@@ -214,7 +220,7 @@ Anyone who wishes to contribute to this project, whether documentation, features
 
 To join, just raise your hand on the [Pathway Discord server](https://discord.com/invite/pathway) (#get-help) or the GitHub [discussion](https://github.com/pathwaycom/llm-app/discussions) board.
 
-If you are unfamiliar with how to contribute to GitHub projects, here is a [Getting Started Guide](https://docs.github.com/en/get-started/quickstart/contributing-to-projects). A full set of contribution guidelines, along with templates, are in progress.
+If you are unfamiliar with how to contribute to GitHub projects, here is a [Get Started Guide](https://docs.github.com/en/get-started/quickstart/contributing-to-projects). A full set of contribution guidelines, along with templates, are in progress.
 
 ## Supported and maintained by
 


### PR DESCRIPTION
Some changes have been applied to the Readme file based on improvement suggestions:

1. Avoid gerunds in your headers, ex: "Get started" instead of "Getting started".
2. Added Prerequisite section.