### PR TITLE
Add support for Azure, Palm, Anthropic, Cohere, Hugging Face Llama2 70b Models - using litellm

### DIFF
--- a/llm_app/model_wrappers/api_clients/clients.py
+++ b/llm_app/model_wrappers/api_clients/clients.py
@@ -14,22 +14,22 @@ class APIClient(ABC):
 
 class OpenAIClient(APIClient):
     def __init__(self, api_key: str):
-        import openai
+        import litellm
 
-        self.api = openai
+        self.api = litellm
         self.api.api_key = api_key
 
 
 class OpenAIChatCompletionClient(OpenAIClient):
     def make_request(self, **kwargs):
         logfun("Calling OpenAI chat completion service %s", str(kwargs)[:100])
-        return self.api.ChatCompletion.create(**kwargs)
+        return self.api.completion(**kwargs)
 
 
 class OpenAIEmbeddingClient(OpenAIClient):
     def make_request(self, **kwargs):
         logfun("Calling OpenAI embedding service %s", str(kwargs)[:100])
-        return self.api.Embedding.create(**kwargs)
+        return self.api.embedding(**kwargs)
 
 
 class HuggingFaceClient(APIClient):


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm/

All LLM API Models are guaranteed to have the same Input/Output interface 

Here's a sample of how it's used:

```python
from litellm import completion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"
os.environ["HF_API_TOKEN"] = "hf-key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# hugging face llama2 call
completion(model="meta-llama/llama-2-7b-hf", messages=messages)

# hugging face llama2 Guanaco call
completion(model="TheBloke/llama-2-70b-Guanaco-QLoRA-fp16", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```
