### PR TITLE
Set docker-compose yaml version to 3.11 for slides search

### DIFF
--- a/examples/pipelines/slides_search/docker-compose.yml
+++ b/examples/pipelines/slides_search/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.11.9'
+version: '3.11'
 
 services:
   app:


### PR DESCRIPTION
Fixes this:

```
$ docker-compose up
ERROR: Version "3.11.9" in ".\docker-compose.yml" is invalid.
```

### Introduction
To contribute code to the Pathway project, start by discussing your proposed changes on Discord or by filing an issue. 
Once approved, follow the fork + pull request model against the main branch, ensuring you've signed the contributor license agreement.

### Context
<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. 
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project,
- [ ] My change requires a change to the documentation,
- [ ] I described the modification in the CHANGELOG.md file.