### PR TITLE
feat: add MiniMax provider (M3 default) to RAG templates

### DIFF
--- a/templates/adaptive_rag/.env.example
+++ b/templates/adaptive_rag/.env.example
@@ -1,1 +1,2 @@
 OPENAI_API_KEY="sk-***"
+# MINIMAX_API_KEY="your-minimax-api-key"  # Optional: use MiniMax instead of OpenAI

--- a/templates/adaptive_rag/app.yaml
+++ b/templates/adaptive_rag/app.yaml
@@ -54,6 +54,17 @@ $llm: !pw.xpacks.llm.llms.OpenAIChat
   temperature: 0
   capacity: 8
 
+# Alternatively, use MiniMax with its OpenAI-compatible API (https://api.minimax.io/v1):
+# $llm: !pw.xpacks.llm.llms.OpenAIChat
+#   model: "MiniMax-M2.7"
+#   api_key: $MINIMAX_API_KEY
+#   base_url: "https://api.minimax.io/v1"
+#   retry_strategy: !pw.udfs.ExponentialBackoffRetryStrategy
+#     max_retries: 6
+#   cache_strategy: !pw.udfs.DefaultCache {}
+#   temperature: 1.0
+#   capacity: 8
+
 # Specifies the embedder model for converting text into embeddings.
 $embedder: !pw.xpacks.llm.embedders.OpenAIEmbedder
   model: "text-embedding-3-small"

--- a/templates/adaptive_rag/app.yaml
+++ b/templates/adaptive_rag/app.yaml
@@ -56,7 +56,7 @@ $llm: !pw.xpacks.llm.llms.OpenAIChat
 
 # Alternatively, use MiniMax with its OpenAI-compatible API (https://api.minimax.io/v1):
 # $llm: !pw.xpacks.llm.llms.OpenAIChat
-#   model: "MiniMax-M2.7"
+#   model: "MiniMax-M3"
 #   api_key: $MINIMAX_API_KEY
 #   base_url: "https://api.minimax.io/v1"
 #   retry_strategy: !pw.udfs.ExponentialBackoffRetryStrategy

--- a/templates/multimodal_rag/.env.example
+++ b/templates/multimodal_rag/.env.example
@@ -1,1 +1,2 @@
 OPENAI_API_KEY="sk-***"
+# MINIMAX_API_KEY="your-minimax-api-key"  # Optional: use MiniMax instead of OpenAI

--- a/templates/multimodal_rag/app.yaml
+++ b/templates/multimodal_rag/app.yaml
@@ -57,7 +57,7 @@ $llm: !pw.xpacks.llm.llms.OpenAIChat
 
 # Alternatively, use MiniMax with its OpenAI-compatible API (https://api.minimax.io/v1):
 # $llm: !pw.xpacks.llm.llms.OpenAIChat
-#   model: "MiniMax-M2.7"
+#   model: "MiniMax-M3"
 #   api_key: $MINIMAX_API_KEY
 #   base_url: "https://api.minimax.io/v1"
 #   retry_strategy: !pw.udfs.ExponentialBackoffRetryStrategy

--- a/templates/multimodal_rag/app.yaml
+++ b/templates/multimodal_rag/app.yaml
@@ -55,6 +55,18 @@ $llm: !pw.xpacks.llm.llms.OpenAIChat
   capacity: 8
   async_mode: "fully_async"
 
+# Alternatively, use MiniMax with its OpenAI-compatible API (https://api.minimax.io/v1):
+# $llm: !pw.xpacks.llm.llms.OpenAIChat
+#   model: "MiniMax-M2.7"
+#   api_key: $MINIMAX_API_KEY
+#   base_url: "https://api.minimax.io/v1"
+#   retry_strategy: !pw.udfs.ExponentialBackoffRetryStrategy
+#     max_retries: 6
+#   cache_strategy: !pw.udfs.DefaultCache {}
+#   temperature: 1.0
+#   capacity: 8
+#   async_mode: "fully_async"
+
 # Specifies the embedder model for converting text into embeddings.
 $embedder: !pw.xpacks.llm.embedders.OpenAIEmbedder
   model: "text-embedding-3-small"

--- a/templates/question_answering_rag/.env.example
+++ b/templates/question_answering_rag/.env.example
@@ -1,1 +1,2 @@
 OPENAI_API_KEY="sk-***"
+# MINIMAX_API_KEY="your-minimax-api-key"  # Optional: use MiniMax instead of OpenAI

--- a/templates/question_answering_rag/app.yaml
+++ b/templates/question_answering_rag/app.yaml
@@ -54,6 +54,18 @@ $llm: !pw.xpacks.llm.llms.OpenAIChat
   capacity: 8
   async_mode: "fully_async"
 
+# Alternatively, use MiniMax with its OpenAI-compatible API (https://api.minimax.io/v1):
+# $llm: !pw.xpacks.llm.llms.OpenAIChat
+#   model: "MiniMax-M2.7"
+#   api_key: $MINIMAX_API_KEY
+#   base_url: "https://api.minimax.io/v1"
+#   retry_strategy: !pw.udfs.ExponentialBackoffRetryStrategy
+#     max_retries: 6
+#   cache_strategy: !pw.udfs.DefaultCache {}
+#   temperature: 1.0
+#   capacity: 8
+#   async_mode: "fully_async"
+
 # Specifies the embedder model for converting text into embeddings.
 $embedder: !pw.xpacks.llm.embedders.OpenAIEmbedder
   model: "text-embedding-3-small"

--- a/templates/question_answering_rag/app.yaml
+++ b/templates/question_answering_rag/app.yaml
@@ -56,7 +56,7 @@ $llm: !pw.xpacks.llm.llms.OpenAIChat
 
 # Alternatively, use MiniMax with its OpenAI-compatible API (https://api.minimax.io/v1):
 # $llm: !pw.xpacks.llm.llms.OpenAIChat
-#   model: "MiniMax-M2.7"
+#   model: "MiniMax-M3"
 #   api_key: $MINIMAX_API_KEY
 #   base_url: "https://api.minimax.io/v1"
 #   retry_strategy: !pw.udfs.ExponentialBackoffRetryStrategy

--- a/templates/slides_ai_search/.env.example
+++ b/templates/slides_ai_search/.env.example
@@ -1,2 +1,3 @@
 OPENAI_API_KEY="YOUR OPENAI_API_KEY"
 PATHWAY_LICENSE_KEY="YOUR PATHWAY KEY"  # can be obtained here: https://pathway.com/user/license
+# MINIMAX_API_KEY="your-minimax-api-key"  # Optional: use MiniMax instead of OpenAI

--- a/templates/slides_ai_search/app.yaml
+++ b/templates/slides_ai_search/app.yaml
@@ -57,7 +57,7 @@ llm: !pw.xpacks.llm.llms.OpenAIChat
 
 # Alternatively, use MiniMax with its OpenAI-compatible API (https://api.minimax.io/v1):
 # llm: !pw.xpacks.llm.llms.OpenAIChat
-#   model: "MiniMax-M2.7"
+#   model: "MiniMax-M3"
 #   api_key: $MINIMAX_API_KEY
 #   base_url: "https://api.minimax.io/v1"
 #   retry_strategy: !pw.udfs.ExponentialBackoffRetryStrategy

--- a/templates/slides_ai_search/app.yaml
+++ b/templates/slides_ai_search/app.yaml
@@ -55,6 +55,20 @@ llm: !pw.xpacks.llm.llms.OpenAIChat
   capacity: 8 # reduce this in case you are hitting API throttle limits
   async_mode: "fully_async"
 
+# Alternatively, use MiniMax with its OpenAI-compatible API (https://api.minimax.io/v1):
+# llm: !pw.xpacks.llm.llms.OpenAIChat
+#   model: "MiniMax-M2.7"
+#   api_key: $MINIMAX_API_KEY
+#   base_url: "https://api.minimax.io/v1"
+#   retry_strategy: !pw.udfs.ExponentialBackoffRetryStrategy
+#     max_retries: 6
+#     initial_delay: 2500
+#     backoff_factor: 2.5
+#   cache_strategy: !pw.udfs.DefaultCache {}
+#   temperature: 1.0
+#   capacity: 8
+#   async_mode: "fully_async"
+
 # Specifies the embedder model for converting text into embeddings.
 $embedder: !pw.xpacks.llm.embedders.OpenAIEmbedder
   cache_strategy: !pw.udfs.DefaultCache {}


### PR DESCRIPTION
## Summary

This PR adds [MiniMax](https://platform.minimax.io) as an alternative LLM provider option to the Pathway RAG templates, with `MiniMax-M3` (the latest model) as the default example.

MiniMax offers an OpenAI-compatible API at `https://api.minimax.io/v1`, which means it can be used as a drop-in replacement for OpenAI models via `pw.xpacks.llm.llms.OpenAIChat` by setting `base_url` and `api_key`.

### Changes

- Added commented MiniMax configuration examples to `app.yaml` in `adaptive_rag`, `question_answering_rag`, `multimodal_rag`, and `slides_ai_search` templates (using `MiniMax-M3` as the default model)
- Added `MINIMAX_API_KEY` to the corresponding `.env.example` files
- `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` remain available as alternative model IDs users can plug in

### How to use MiniMax

Uncomment the MiniMax section in any template's `app.yaml` and set `MINIMAX_API_KEY` in your `.env` file. By default the example uses `MiniMax-M3` (512K context, up to 128K output, image input supported); swap the `model` field to `MiniMax-M2.7` if you prefer the previous generation.

**Note:** MiniMax requires `temperature` to be in the range `(0.0, 1.0]`.

API Reference: https://platform.minimax.io/docs/api-reference/text-openai-api