### PR TITLE
Add MiniMax M3 and M2.7 provider config to RAG templates

### DIFF
--- a/templates/adaptive_rag/.env.example
+++ b/templates/adaptive_rag/.env.example
@@ -1,1 +1,3 @@
 OPENAI_API_KEY="sk-***"
+# Optional: use MiniMax instead of OpenAI. Global: https://api.minimax.io/v1  CN: https://api.minimaxi.com/v1
+# MINIMAX_API_KEY="your-minimax-api-key"

--- a/templates/adaptive_rag/app.yaml
+++ b/templates/adaptive_rag/app.yaml
@@ -54,6 +54,38 @@ $llm: !pw.xpacks.llm.llms.OpenAIChat
   temperature: 0
   capacity: 8
 
+# Alternatively, use MiniMax via its OpenAI-compatible API.
+# MiniMax-M3: 1,000,000-token context window; supports text, image, and video input.
+# MiniMax-M2.7: 204,800-token context window; supports text input.
+# Global endpoint: https://api.minimax.io/v1
+# CN endpoint:     https://api.minimaxi.com/v1
+# Set MINIMAX_API_KEY in your .env file, then uncomment one of the blocks below.
+# MiniMax requires temperature in the range (0.0, 1.0].
+
+# MiniMax-M3 (global endpoint)
+# $llm: !pw.xpacks.llm.llms.OpenAIChat
+#   model: "MiniMax-M3"
+#   api_key: $MINIMAX_API_KEY
+#   base_url: "https://api.minimax.io/v1"
+#   # base_url: "https://api.minimaxi.com/v1"  # CN endpoint
+#   retry_strategy: !pw.udfs.ExponentialBackoffRetryStrategy
+#     max_retries: 6
+#   cache_strategy: !pw.udfs.DefaultCache {}
+#   temperature: 1.0
+#   capacity: 8
+
+# MiniMax-M2.7 (global endpoint)
+# $llm: !pw.xpacks.llm.llms.OpenAIChat
+#   model: "MiniMax-M2.7"
+#   api_key: $MINIMAX_API_KEY
+#   base_url: "https://api.minimax.io/v1"
+#   # base_url: "https://api.minimaxi.com/v1"  # CN endpoint
+#   retry_strategy: !pw.udfs.ExponentialBackoffRetryStrategy
+#     max_retries: 6
+#   cache_strategy: !pw.udfs.DefaultCache {}
+#   temperature: 1.0
+#   capacity: 8
+
 # Specifies the embedder model for converting text into embeddings.
 $embedder: !pw.xpacks.llm.embedders.OpenAIEmbedder
   model: "text-embedding-3-small"

--- a/templates/multimodal_rag/.env.example
+++ b/templates/multimodal_rag/.env.example
@@ -1,1 +1,3 @@
 OPENAI_API_KEY="sk-***"
+# Optional: use MiniMax instead of OpenAI. Global: https://api.minimax.io/v1  CN: https://api.minimaxi.com/v1
+# MINIMAX_API_KEY="your-minimax-api-key"

--- a/templates/multimodal_rag/app.yaml
+++ b/templates/multimodal_rag/app.yaml
@@ -55,6 +55,40 @@ $llm: !pw.xpacks.llm.llms.OpenAIChat
   capacity: 8
   async_mode: "fully_async"
 
+# Alternatively, use MiniMax via its OpenAI-compatible API.
+# MiniMax-M3: 1,000,000-token context window; supports text, image, and video input.
+# MiniMax-M2.7: 204,800-token context window; supports text input.
+# Global endpoint: https://api.minimax.io/v1
+# CN endpoint:     https://api.minimaxi.com/v1
+# Set MINIMAX_API_KEY in your .env file, then uncomment one of the blocks below.
+# MiniMax requires temperature in the range (0.0, 1.0].
+
+# MiniMax-M3 (global endpoint)
+# $llm: !pw.xpacks.llm.llms.OpenAIChat
+#   model: "MiniMax-M3"
+#   api_key: $MINIMAX_API_KEY
+#   base_url: "https://api.minimax.io/v1"
+#   # base_url: "https://api.minimaxi.com/v1"  # CN endpoint
+#   retry_strategy: !pw.udfs.ExponentialBackoffRetryStrategy
+#     max_retries: 6
+#   cache_strategy: !pw.udfs.DefaultCache {}
+#   temperature: 1.0
+#   capacity: 8
+#   async_mode: "fully_async"
+
+# MiniMax-M2.7 (global endpoint)
+# $llm: !pw.xpacks.llm.llms.OpenAIChat
+#   model: "MiniMax-M2.7"
+#   api_key: $MINIMAX_API_KEY
+#   base_url: "https://api.minimax.io/v1"
+#   # base_url: "https://api.minimaxi.com/v1"  # CN endpoint
+#   retry_strategy: !pw.udfs.ExponentialBackoffRetryStrategy
+#     max_retries: 6
+#   cache_strategy: !pw.udfs.DefaultCache {}
+#   temperature: 1.0
+#   capacity: 8
+#   async_mode: "fully_async"
+
 # Specifies the embedder model for converting text into embeddings.
 $embedder: !pw.xpacks.llm.embedders.OpenAIEmbedder
   model: "text-embedding-3-small"

--- a/templates/question_answering_rag/.env.example
+++ b/templates/question_answering_rag/.env.example
@@ -1,1 +1,3 @@
 OPENAI_API_KEY="sk-***"
+# Optional: use MiniMax instead of OpenAI. Global: https://api.minimax.io/v1  CN: https://api.minimaxi.com/v1
+# MINIMAX_API_KEY="your-minimax-api-key"

--- a/templates/question_answering_rag/app.yaml
+++ b/templates/question_answering_rag/app.yaml
@@ -54,6 +54,40 @@ $llm: !pw.xpacks.llm.llms.OpenAIChat
   capacity: 8
   async_mode: "fully_async"
 
+# Alternatively, use MiniMax via its OpenAI-compatible API.
+# MiniMax-M3: 1,000,000-token context window; supports text, image, and video input.
+# MiniMax-M2.7: 204,800-token context window; supports text input.
+# Global endpoint: https://api.minimax.io/v1
+# CN endpoint:     https://api.minimaxi.com/v1
+# Set MINIMAX_API_KEY in your .env file, then uncomment one of the blocks below.
+# MiniMax requires temperature in the range (0.0, 1.0].
+
+# MiniMax-M3 (global endpoint)
+# $llm: !pw.xpacks.llm.llms.OpenAIChat
+#   model: "MiniMax-M3"
+#   api_key: $MINIMAX_API_KEY
+#   base_url: "https://api.minimax.io/v1"
+#   # base_url: "https://api.minimaxi.com/v1"  # CN endpoint
+#   retry_strategy: !pw.udfs.ExponentialBackoffRetryStrategy
+#     max_retries: 6
+#   cache_strategy: !pw.udfs.DefaultCache {}
+#   temperature: 1.0
+#   capacity: 8
+#   async_mode: "fully_async"
+
+# MiniMax-M2.7 (global endpoint)
+# $llm: !pw.xpacks.llm.llms.OpenAIChat
+#   model: "MiniMax-M2.7"
+#   api_key: $MINIMAX_API_KEY
+#   base_url: "https://api.minimax.io/v1"
+#   # base_url: "https://api.minimaxi.com/v1"  # CN endpoint
+#   retry_strategy: !pw.udfs.ExponentialBackoffRetryStrategy
+#     max_retries: 6
+#   cache_strategy: !pw.udfs.DefaultCache {}
+#   temperature: 1.0
+#   capacity: 8
+#   async_mode: "fully_async"
+
 # Specifies the embedder model for converting text into embeddings.
 $embedder: !pw.xpacks.llm.embedders.OpenAIEmbedder
   model: "text-embedding-3-small"

--- a/templates/slides_ai_search/.env.example
+++ b/templates/slides_ai_search/.env.example
@@ -1,2 +1,4 @@
 OPENAI_API_KEY="YOUR OPENAI_API_KEY"
 PATHWAY_LICENSE_KEY="YOUR PATHWAY KEY"  # can be obtained here: https://pathway.com/user/license
+# Optional: use MiniMax instead of OpenAI. Global: https://api.minimax.io/v1  CN: https://api.minimaxi.com/v1
+# MINIMAX_API_KEY="your-minimax-api-key"

--- a/templates/slides_ai_search/app.yaml
+++ b/templates/slides_ai_search/app.yaml
@@ -55,6 +55,44 @@ llm: !pw.xpacks.llm.llms.OpenAIChat
   capacity: 8 # reduce this in case you are hitting API throttle limits
   async_mode: "fully_async"
 
+# Alternatively, use MiniMax via its OpenAI-compatible API.
+# MiniMax-M3: 1,000,000-token context window; supports text, image, and video input.
+# MiniMax-M2.7: 204,800-token context window; supports text input.
+# Global endpoint: https://api.minimax.io/v1
+# CN endpoint:     https://api.minimaxi.com/v1
+# Set MINIMAX_API_KEY in your .env file, then uncomment one of the blocks below.
+# MiniMax requires temperature in the range (0.0, 1.0].
+
+# MiniMax-M3 (global endpoint)
+# llm: !pw.xpacks.llm.llms.OpenAIChat
+#   model: "MiniMax-M3"
+#   api_key: $MINIMAX_API_KEY
+#   base_url: "https://api.minimax.io/v1"
+#   # base_url: "https://api.minimaxi.com/v1"  # CN endpoint
+#   retry_strategy: !pw.udfs.ExponentialBackoffRetryStrategy
+#     max_retries: 6
+#     initial_delay: 2500
+#     backoff_factor: 2.5
+#   cache_strategy: !pw.udfs.DefaultCache {}
+#   temperature: 1.0
+#   capacity: 8
+#   async_mode: "fully_async"
+
+# MiniMax-M2.7 (global endpoint)
+# llm: !pw.xpacks.llm.llms.OpenAIChat
+#   model: "MiniMax-M2.7"
+#   api_key: $MINIMAX_API_KEY
+#   base_url: "https://api.minimax.io/v1"
+#   # base_url: "https://api.minimaxi.com/v1"  # CN endpoint
+#   retry_strategy: !pw.udfs.ExponentialBackoffRetryStrategy
+#     max_retries: 6
+#     initial_delay: 2500
+#     backoff_factor: 2.5
+#   cache_strategy: !pw.udfs.DefaultCache {}
+#   temperature: 1.0
+#   capacity: 8
+#   async_mode: "fully_async"
+
 # Specifies the embedder model for converting text into embeddings.
 $embedder: !pw.xpacks.llm.embedders.OpenAIEmbedder
   cache_strategy: !pw.udfs.DefaultCache {}


### PR DESCRIPTION
Reason: Add executable MiniMax M3 and M2.7 provider configuration to the RAG templates.

This PR adds MiniMax as an alternative LLM provider to the `adaptive_rag`, `question_answering_rag`, `multimodal_rag`, and `slides_ai_search` templates, following the repo's existing pattern of commented alternative LLM blocks in `app.yaml`.

### Changes

- Added commented MiniMax configuration blocks to `app.yaml` in four RAG templates, covering both `MiniMax-M3` and `MiniMax-M2.7` models.
- Each model block includes the global endpoint (`https://api.minimax.io/v1`) and the CN endpoint (`https://api.minimaxi.com/v1`) as a one-line swap.
- MiniMax-M3 is documented with a 1,000,000-token context window; MiniMax-M2.7 with a 204,800-token context window.
- Added `MINIMAX_API_KEY` to the corresponding `.env.example` files.

### Verification

- Confirmed the diff only adds comment lines and blank lines to YAML/env files; no existing executable YAML structure was changed.
- The templates still default to OpenAI; MiniMax blocks are ready to uncomment and use.
